### PR TITLE
Improved count extraction

### DIFF
--- a/diagnosis/feature_extractors.py
+++ b/diagnosis/feature_extractors.py
@@ -108,7 +108,7 @@ def extract_counts(text):
                     'text' : m.group(1).string,
                     'textOffsets' : [start_offset, start_offset + len(m.group(1).string)]
                 }, **args)
-    number_pattern = '{CD+ CC? CD? CD?}'
+    number_pattern = '{CD+ and? CD? CD?}'
     counts = []
     counts += list(yield_search_results([
         number_pattern + ' JJ*? JJ*? PATIENT|CASE|INFECTION',
@@ -146,7 +146,9 @@ def extract_counts(text):
                 if count2.get('type') == 'hospitalizationCount' or\
                    count2.get('type') == 'deathCount':
                     out_count = count2
-        out_counts.append(out_count)
+        # Remove copied counts created during replacement
+        if out_count not in out_counts:
+            out_counts.append(out_count)
     for count in out_counts: yield count
 
 def extract_dates(text):

--- a/test/test_count_extractor.py
+++ b/test/test_count_extractor.py
@@ -3,7 +3,6 @@ import unittest
 from diagnosis.feature_extractors import extract_counts
 
 class TestCountExtractor(unittest.TestCase):
-
     def test_verbal_counts(self):
         examples = {
             "it brings the number of cases reported in Jeddah since 27 Mar 2014 to 28" : 28,
@@ -57,3 +56,8 @@ class TestCountExtractor(unittest.TestCase):
         example = "These 2 new cases bring to 4 the number of people stricken in California this year [2012]."
         count_set = set([count['value'] for count in extract_counts(example)])
         self.assertSetEqual(count_set, set([2,4]))
+
+    def test_duplicates(self):
+        example = "Two patients died out of four patients."
+        counts = [c['value'] for c in extract_counts(example)]
+        self.assertListEqual(counts, [2,4])


### PR DESCRIPTION
Highlights:
- Added a monkey patch for better CD parsing.
- New query for case counts: number_pattern + ' *? *? *? *? *? *? *? INFECT|AFFLICT'
- Checking count type in some of the tests
- Fixed some query bugs e.g. `VP|TO` doesn't work because VP finds chunks and TO finds words.
