### PR TITLE
Adding route for BSVE search API

### DIFF
--- a/config.sample.py
+++ b/config.sample.py
@@ -7,3 +7,4 @@ mongo_url = 'localhost'
 bsve_user_name = "a@b.c"
 bsve_api_key = "asdf"
 bsve_secret_key = "qwerty"
+bsve_endpoint = "http://search.bsvecosystem.net"


### PR DESCRIPTION
This route enables us to use the BSVE text search API in JS apps without exposing our auth keys. To use this endpoint, the BSVE auth variables from config.sample.py need to be added to config.py.

Information about the BSVE text search API is available here:
http://developer.bsvecosystem.net/wp/tutorials/api-documentation-sub1/

The request body is passed through to the BSVE API and the final response is passed back to the client without modification. Rather than implement the BSVE's request and result endpoints, I created a single endpoint that will poll the result endpoint until the results are ready and return them in response to the original request.
