### PR TITLE
Fixing error on no search results in the BSVE proxy

### DIFF
--- a/server.py
+++ b/server.py
@@ -170,10 +170,6 @@ class BSVEHandler(tornado.web.RequestHandler):
                                 "harbinger-authentication": auth_header
                             },
                             method="GET"), search_result_cb))
-                elif parsed_resp['status'] == -1:
-                    self.set_status(500)
-                    self.write('Result Error:\n' + resp.body)
-                    self.finish()
                 else:
                     self.write(resp.body)
                     self.set_header("Content-Type", "application/json")


### PR DESCRIPTION
I thought the status code -1 indicated errors, but it is used when there are no search results for a particular term, so it should not trigger 500s.
