### PR TITLE
Add content_date parameter to API

### DIFF
--- a/diagnosis/Diagnoser.py
+++ b/diagnosis/Diagnoser.py
@@ -59,7 +59,7 @@ class Diagnoser():
                     if label in parents:
                         result[i2] = max(p, probs[i2], result.get(i2, 0))
         return result.items()
-    def diagnose(self, content, diseases_only=False):
+    def diagnose(self, content, diseases_only=False, content_date=None):
         time_sofar = time_sofar_gen(datetime.datetime.now())
         base_keyword_dict = self.keyword_extractor.transform([content])[0]
         feature_dict = self.keyword_processor.transform([base_keyword_dict])
@@ -106,7 +106,7 @@ class Diagnoser():
             }
         logger.info(time_sofar.next() + 'Diagnosed diseases')
 
-        anno_doc = AnnoDoc(content)
+        anno_doc = AnnoDoc(content, date=content_date)
         anno_doc.add_tier(self.keyword_annotator)
         logger.info('keywords annotated')
         try:

--- a/tasks_diagnose.py
+++ b/tasks_diagnose.py
@@ -96,7 +96,7 @@ def diagnose_girder_resource(prev_result=None, item_id=None):
     return make_json_compat(resource)
 
 @celery_tasks.task(base=DiagnoserTask, name='tasks.diagnose')
-def diagnose(text_obj, diseases_only=False):
+def diagnose(text_obj, extra_args):
     english_translation = text_obj.get('englishTranslation', {}).get('content')
     if english_translation:
         clean_english_content = english_translation
@@ -105,6 +105,6 @@ def diagnose(text_obj, diseases_only=False):
     if clean_english_content:
         logger.info('Diagnosing text:\n' + clean_english_content)
         return make_json_compat(diagnose.diagnoser.diagnose(
-            clean_english_content, diseases_only))
+            clean_english_content, **extra_args))
     else:
         return { 'error' : 'No content available to diagnose.' }

--- a/tasks_preprocess.py
+++ b/tasks_preprocess.py
@@ -45,9 +45,9 @@ logger = logging.getLogger(__name__)
 celery_tasks = Celery('tasks', broker=config.BROKER_URL)
 
 celery_tasks.conf.update(
-    CELERY_TASK_SERIALIZER='json',
-    CELERY_ACCEPT_CONTENT=['json'],  # Ignore other content
-    CELERY_RESULT_SERIALIZER='json',
+    CELERY_TASK_SERIALIZER='pickle',
+    CELERY_ACCEPT_CONTENT=['pickle'],  # Ignore other content
+    CELERY_RESULT_SERIALIZER='pickle',
     CELERY_RESULT_BACKEND = config.BROKER_URL
 )
 


### PR DESCRIPTION
The content_date parameter specifies a date that "today" references are resolved to.

Other changes:
* I switched celery to use pickle serialization so python date objects can be passed to workers.
* The switch to redis allowed us to retrieve exception information from workers, so that is now passed back to the client.
